### PR TITLE
Get it working in docker

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,0 +1,34 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [ 'main' ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image and push to registry
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: 'ghcr.io/hathitrust/ptsearch-solr-unstable:${{ github.sha }}, ghcr.io/hathitrust/ptsearch-solr-unstable:latest'
+          file: Dockerfile
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM solr:8
+
+COPY --chown=solr:solr . /var/solr/data/ptsearch

--- a/conf/solrconfig.xml
+++ b/conf/solrconfig.xml
@@ -37,15 +37,6 @@
   -->
   <luceneMatchVersion>8.0.0</luceneMatchVersion>
 
-  <!-- Data Directory
-
-       Used to specify an alternate directory to hold all index data
-       other than the default ./data under the Solr home.  If
-       replication is in use, this should match the replication
-       configuration.
-    -->
-  <dataDir>${solr.data.dir:./data}</dataDir>
-  <lib dir="${solr.core.config}/lib" regex=".*\.jar"/>
   <!-- The DirectoryFactory to use for indexes.
 
        solr.StandardDirectoryFactory is filesystem

--- a/core.properties
+++ b/core.properties
@@ -1,0 +1,1 @@
+name=ptsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+
+  solr:
+    build: .
+    ports:
+      - "8983:8983"


### PR DESCRIPTION
- Core autodiscovery requires that core.properties exists
- Data and lib dir were provoking errors and warnings; the defaults work
just fine.

To try it, just do:

```
git clone
docker-compose build
docker-compose up
```

go to http://localhost:8983