### PR TITLE
Fix image path in GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             - name: Build Image
               uses: hathitrust/github_actions/build@v1
               with:
-                image: ghcr.io/hathitrust/${{ github.repository }}
+                image: ghcr.io/${{ github.repository }}
                 dockerfile: Dockerfile
                 img_tag: ${{ inputs.img_tag }}
                 tag: ${{ inputs.ref }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
                 - name: Deploy to ${{inputs.environments}}
                   uses: hathitrust/github_actions/deploy@v1
                   with:
-                    image: ghcr.io/hathitrust/${{ github.repository }}:${{ inputs.branch_hash || github.sha}}
+                    image: ghcr.io/${{ github.repository }}:${{ inputs.branch_hash || github.sha}}
                     file: environments/ptsearch/${{inputs.environments}}/ptsearch-solr.txt
                     CONFIG_REPO_RW_APP_ID: ${{ vars.CONFIG_REPO_RW_APP_ID }}
                     CONFIG_REPO_FULL_NAME: ${{ vars.CONFIG_REPO_FULL_NAME }}

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -11,6 +11,6 @@ jobs:
       - uses: hathitrust/github_actions/tag-release@v1
         with:
           registry_token: ${{ github.token }}
-          existing_tag: ghcr.io/hathitrust/${{ github.repository }}:${{ github.sha }}
+          existing_tag: ghcr.io/${{ github.repository }}:${{ github.sha }}
           image: ghcr.io/hathitrust/${{ github.repository }}
           new_tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Previously we were seeing a double `hathitrust/hathitrust` in the image url. The leading one has been removed since `hathitrust` comes over in the repository name.