### PR TITLE
replace outdated tag-release action

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -12,5 +12,5 @@ jobs:
         with:
           registry_token: ${{ github.token }}
           existing_tag: ghcr.io/${{ github.repository }}:${{ github.sha }}
-          image: ghcr.io/hathitrust/${{ github.repository }}
+          image: ghcr.io/${{ github.repository }}
           new_tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
The old tag-release action ended up creating an image with an extra 'hathitrust/' in it.